### PR TITLE
Feat(#31): [domain] repository 정의 - CommitRepository

### DIFF
--- a/domain/src/main/java/com/takseha/domain/model/commit/CommitComment.kt
+++ b/domain/src/main/java/com/takseha/domain/model/commit/CommitComment.kt
@@ -1,0 +1,11 @@
+package com.takseha.domain.model.commit
+
+data class CommitComment(
+    val id: Int,
+    val studyId: Int,
+    val writerName: String,
+    val writerProfileUrl: String,
+    val content: String,
+    val createdAt: String,
+    val isMyComment: Boolean
+)

--- a/domain/src/main/java/com/takseha/domain/model/commit/PostCommitCommentParam.kt
+++ b/domain/src/main/java/com/takseha/domain/model/commit/PostCommitCommentParam.kt
@@ -1,0 +1,6 @@
+package com.takseha.domain.model.commit
+
+data class PostCommitCommentParam(
+    val studyId: Int,
+    val comment: String
+)

--- a/domain/src/main/java/com/takseha/domain/repository/CommitRepository.kt
+++ b/domain/src/main/java/com/takseha/domain/repository/CommitRepository.kt
@@ -1,0 +1,34 @@
+package com.takseha.domain.repository
+
+import com.takseha.domain.model.commit.CommitComment
+import com.takseha.domain.model.commit.CommitDetail
+import com.takseha.domain.model.commit.PostCommitCommentParam
+import com.takseha.domain.model.todo.CommitSummary
+
+interface CommitRepository {
+    /** 마이커밋 리스트 조회 */
+    suspend fun getMyCommits(cursorIdx: Long?, limit: Long, studyId: Int): List<CommitSummary>
+    suspend fun fetchMyCommits(cursorIdx: Long?, limit: Long, studyId: Int): List<CommitSummary>
+
+    /** 커밋 상세 정보 조회 */
+    suspend fun getCommitDetail(studyId: Int, commitId: Int): CommitDetail
+    suspend fun fetchCommitDetail(studyId: Int, commitId: Int): CommitDetail
+
+    /** 커밋 승인 */
+    suspend fun approveCommit(studyId: Int, commitId: Int)
+
+    /** 커밋 반려 */
+    suspend fun rejectCommit(studyId: Int, commitId: Int)
+
+    /** 커밋 댓글 리스트 조회 */
+    suspend fun fetchCommitComments(studyId: Int, commitId: Int): List<CommitComment>
+
+    /** 커밋 댓글 등록 */
+    suspend fun postCommitComment(commitId: Int, postCommitCommentParam: PostCommitCommentParam)
+
+    /** 커밋 댓글 수정 */
+    suspend fun updateCommitComment(commitId: Int, postCommitCommentParam: PostCommitCommentParam)
+
+    /** 커밋 댓글 삭제 */
+    suspend fun deleteCommitComment(commitId: Int, commentId: Int)
+}


### PR DESCRIPTION
## ☝️연관된 이슈

<b>#31</b>

## ✌️구현 내용
> 📌 요약: `CommitRepository` 인터페이스 정의

  - getCommitDetail()
: 커밋 상세 정보 조회
  - fetchCommitDetail()
: 커밋 상세 정보 서버 조회

  - approveCommit()
: 커밋 승인

  - rejectCommit()
: 커밋 반려

  - fetchCommitComments()
: 커밋 댓글 리스트 조회
  - postCommitComment()
: 커밋 댓글 등록
  - updateCommitComment()
: 커밋 댓글 수정
  - deleteCommitComment()
: 커밋 댓글 삭제
