### PR TITLE
Feat(#47): [domain] usecase 정의 - Todo 관련

### DIFF
--- a/domain/src/main/java/com/takseha/domain/model/mystudy/MyStudyDetail.kt
+++ b/domain/src/main/java/com/takseha/domain/model/mystudy/MyStudyDetail.kt
@@ -1,7 +1,6 @@
 package com.takseha.domain.model.mystudy
 
 import com.takseha.domain.model.study.StudyCycle
-import com.takseha.domain.model.study.StudyRank
 import com.takseha.domain.model.study.StudyStatus
 
 data class MyStudyDetail(
@@ -10,7 +9,6 @@ data class MyStudyDetail(
     val info: String,
     val cycle: StudyCycle,
     val status: StudyStatus,
-    val rankAndScore: StudyRank,
     val studyProfileUrl: String,
     val isLeader: Boolean,
     val githubRepoUrl: String,

--- a/domain/src/main/java/com/takseha/domain/repository/TodoRepository.kt
+++ b/domain/src/main/java/com/takseha/domain/repository/TodoRepository.kt
@@ -1,15 +1,15 @@
 package com.takseha.domain.repository
 
-import com.takseha.domain.model.mystudy.TodoSummary
 import com.takseha.domain.model.todo.CreateTodoParam
 import com.takseha.domain.model.todo.TodoDetail
 
 interface TodoRepository {
     /** 투두 리스트 조회 */
-    suspend fun fetchTodoList(cursorIdx: Long?, limit: Long, studyId: Int): List<TodoSummary>
+    suspend fun getTodoList(cursorIdx: Long?, limit: Long, studyId: Int): List<TodoDetail>?
+    suspend fun fetchTodoList(cursorIdx: Long?, limit: Long, studyId: Int): List<TodoDetail>
 
     /** 투두 상세 정보 조회 */
-    suspend fun getTodoDetail(studyId: Int, todoId: Int): TodoDetail
+    suspend fun getTodoDetail(studyId: Int, todoId: Int): TodoDetail?
     suspend fun fetchTodoDetail(studyId: Int, todoId: Int): TodoDetail
 
     /** 투두 등록 */

--- a/domain/src/main/java/com/takseha/domain/usecase/mystudy/GetMyStudyMembersUseCase.kt
+++ b/domain/src/main/java/com/takseha/domain/usecase/mystudy/GetMyStudyMembersUseCase.kt
@@ -1,0 +1,12 @@
+package com.takseha.domain.usecase.mystudy
+
+import com.takseha.domain.repository.MyStudyRepository
+
+/**
+ * 마이스터디 멤버 리스트 조회 (랭킹순)
+ */
+class GetMyStudyMembersUseCase(
+    private val myStudyRepository: MyStudyRepository
+) {
+    suspend operator fun invoke(studyId: Int) = myStudyRepository.fetchMyStudyMembers(studyId)
+}

--- a/domain/src/main/java/com/takseha/domain/usecase/todo/CreateTodoUseCase.kt
+++ b/domain/src/main/java/com/takseha/domain/usecase/todo/CreateTodoUseCase.kt
@@ -1,0 +1,13 @@
+package com.takseha.domain.usecase.todo
+
+import com.takseha.domain.model.todo.CreateTodoParam
+import com.takseha.domain.repository.TodoRepository
+
+/**
+ * 투두 생성
+ */
+class CreateTodoUseCase(
+    private val todoRepository: TodoRepository
+) {
+    suspend operator fun invoke(studyId: Int, createTodoParam: CreateTodoParam) = todoRepository.createTodo(studyId, createTodoParam)
+}

--- a/domain/src/main/java/com/takseha/domain/usecase/todo/DeleteTodoUseCase.kt
+++ b/domain/src/main/java/com/takseha/domain/usecase/todo/DeleteTodoUseCase.kt
@@ -1,0 +1,12 @@
+package com.takseha.domain.usecase.todo
+
+import com.takseha.domain.repository.TodoRepository
+
+/**
+ * 투두 삭제
+ */
+class DeleteTodoUseCase(
+    private val todoRepository: TodoRepository
+) {
+    suspend operator fun invoke(studyId: Int, todoId: Int) = todoRepository.deleteTodo(studyId, todoId)
+}

--- a/domain/src/main/java/com/takseha/domain/usecase/todo/GetTodoListUseCase.kt
+++ b/domain/src/main/java/com/takseha/domain/usecase/todo/GetTodoListUseCase.kt
@@ -1,0 +1,17 @@
+package com.takseha.domain.usecase.todo
+
+import com.takseha.domain.repository.TodoRepository
+import com.takseha.domain.utils.getOrFetch
+
+/**
+ * 투두 리스트 조회
+ * : Room 먼저 조회(get) -> null이면 서버에서 조회(fetch)
+ */
+class GetTodoListUseCase(
+    private val todoRepository: TodoRepository
+) {
+    suspend operator fun invoke(cursorIdx: Long? = null, limit: Long = 10, studyId: Int) = getOrFetch(
+        get = { todoRepository.getTodoList(cursorIdx, limit, studyId) },
+        fetch = { todoRepository.fetchTodoList(cursorIdx, limit, studyId) }
+    )
+}


### PR DESCRIPTION
## ☝️연관된 이슈

<b>#47</b>

## ✌️구현 내용
> 📌 요약: Todo 관련 usecase 구현

- `GetTodoListUseCase`
: 투두 리스트 조회

- `CreateTodoUseCase`
: 투두 생성

- `DeleteTodoUseCase`
: 투두 삭제
