### PR TITLE
Feat(#49): [domain] usecase 정의 - 커밋 관련

### DIFF
--- a/domain/src/main/java/com/takseha/domain/repository/CommitRepository.kt
+++ b/domain/src/main/java/com/takseha/domain/repository/CommitRepository.kt
@@ -23,7 +23,7 @@ interface CommitRepository {
     suspend fun postCommitComment(commitId: Int, postCommitCommentParam: PostCommitCommentParam)
 
     /** 커밋 댓글 수정 */
-    suspend fun updateCommitComment(commitId: Int, postCommitCommentParam: PostCommitCommentParam)
+    suspend fun updateCommitComment(commitId: Int, updateCommitCommentParam: PostCommitCommentParam)
 
     /** 커밋 댓글 삭제 */
     suspend fun deleteCommitComment(commitId: Int, commentId: Int)

--- a/domain/src/main/java/com/takseha/domain/repository/CommitRepository.kt
+++ b/domain/src/main/java/com/takseha/domain/repository/CommitRepository.kt
@@ -6,7 +6,7 @@ import com.takseha.domain.model.commit.PostCommitCommentParam
 
 interface CommitRepository {
     /** 커밋 상세 정보 조회 */
-    suspend fun getCommitDetail(studyId: Int, commitId: Int): CommitDetail
+    suspend fun getCommitDetail(studyId: Int, commitId: Int): CommitDetail?
     suspend fun fetchCommitDetail(studyId: Int, commitId: Int): CommitDetail
 
     /** 커밋 승인 */
@@ -16,6 +16,7 @@ interface CommitRepository {
     suspend fun rejectCommit(studyId: Int, commitId: Int)
 
     /** 커밋 댓글 리스트 조회 */
+    suspend fun getCommitComments(studyId: Int, commitId: Int): List<CommitComment>?
     suspend fun fetchCommitComments(studyId: Int, commitId: Int): List<CommitComment>
 
     /** 커밋 댓글 등록 */

--- a/domain/src/main/java/com/takseha/domain/usecase/commit/DeleteCommitCommentUseCase.kt
+++ b/domain/src/main/java/com/takseha/domain/usecase/commit/DeleteCommitCommentUseCase.kt
@@ -1,0 +1,13 @@
+package com.takseha.domain.usecase.commit
+
+import com.takseha.domain.repository.CommitRepository
+
+/**
+ * 커밋 댓글 삭제
+ */
+class DeleteCommitCommentUseCase(
+    private val commitRepository: CommitRepository
+) {
+    suspend operator fun invoke(commitId: Int, commentId: Int) =
+        commitRepository.deleteCommitComment(commitId, commentId)
+}

--- a/domain/src/main/java/com/takseha/domain/usecase/commit/GetCommitCommentsUseCase.kt
+++ b/domain/src/main/java/com/takseha/domain/usecase/commit/GetCommitCommentsUseCase.kt
@@ -1,0 +1,17 @@
+package com.takseha.domain.usecase.commit
+
+import com.takseha.domain.repository.CommitRepository
+import com.takseha.domain.utils.getOrFetch
+
+/**
+ * 커밋 댓글 리스트 조회
+ * : Room 먼저 조회(get) -> null이면 서버에서 조회(fetch)
+ */
+class GetCommitCommentsUseCase(
+    private val commitRepository: CommitRepository
+) {
+    suspend operator fun invoke(studyId: Int, commitId: Int) = getOrFetch(
+        get = { commitRepository.getCommitComments(studyId, commitId) },
+        fetch = { commitRepository.fetchCommitComments(studyId, commitId) }
+    )
+}

--- a/domain/src/main/java/com/takseha/domain/usecase/commit/GetCommitDetailUseCase.kt
+++ b/domain/src/main/java/com/takseha/domain/usecase/commit/GetCommitDetailUseCase.kt
@@ -1,0 +1,17 @@
+package com.takseha.domain.usecase.commit
+
+import com.takseha.domain.repository.CommitRepository
+import com.takseha.domain.utils.getOrFetch
+
+/**
+ * 커밋 상세 정보 조회
+ * : Room 먼저 조회(get) -> null이면 서버에서 조회(fetch)
+ */
+class GetCommitDetailUseCase(
+    private val commitRepository: CommitRepository
+) {
+    suspend operator fun invoke(studyId: Int, commitId: Int) = getOrFetch(
+        get = { commitRepository.getCommitDetail(studyId, commitId) },
+        fetch = { commitRepository.fetchCommitDetail(studyId, commitId) }
+    )
+}

--- a/domain/src/main/java/com/takseha/domain/usecase/commit/PostCommitCommentUseCase.kt
+++ b/domain/src/main/java/com/takseha/domain/usecase/commit/PostCommitCommentUseCase.kt
@@ -1,0 +1,14 @@
+package com.takseha.domain.usecase.commit
+
+import com.takseha.domain.model.commit.PostCommitCommentParam
+import com.takseha.domain.repository.CommitRepository
+
+/**
+ * 커밋 댓글 등록
+ */
+class PostCommitCommentUseCase(
+    private val commitRepository: CommitRepository
+) {
+    suspend operator fun invoke(commitId: Int, postCommitCommentParam: PostCommitCommentParam) =
+        commitRepository.postCommitComment(commitId, postCommitCommentParam)
+}

--- a/domain/src/main/java/com/takseha/domain/usecase/commit/RespondToCommitUseCase.kt
+++ b/domain/src/main/java/com/takseha/domain/usecase/commit/RespondToCommitUseCase.kt
@@ -1,0 +1,17 @@
+package com.takseha.domain.usecase.commit
+
+import com.takseha.domain.repository.CommitRepository
+
+/**
+ * 커밋 승인/반려
+ */
+class RespondToCommitUseCase(
+    private val commitRepository: CommitRepository
+) {
+    suspend operator fun invoke(studyId: Int, commitId: Int, isApproved: Boolean) =
+        if (isApproved) {
+            commitRepository.approveCommit(studyId, commitId)
+        } else {
+            commitRepository.rejectCommit(studyId, commitId)
+        }
+}

--- a/domain/src/main/java/com/takseha/domain/usecase/commit/UpdateCommitCommentUseCase.kt
+++ b/domain/src/main/java/com/takseha/domain/usecase/commit/UpdateCommitCommentUseCase.kt
@@ -9,6 +9,6 @@ import com.takseha.domain.repository.CommitRepository
 class UpdateCommitCommentUseCase(
     private val commitRepository: CommitRepository
 ) {
-    suspend operator fun invoke(commitId: Int, postCommitCommentParam: PostCommitCommentParam) =
-        commitRepository.updateCommitComment(commitId, postCommitCommentParam)
+    suspend operator fun invoke(commitId: Int, updateCommitCommentParam: PostCommitCommentParam) =
+        commitRepository.updateCommitComment(commitId, updateCommitCommentParam)
 }

--- a/domain/src/main/java/com/takseha/domain/usecase/commit/UpdateCommitCommentUseCase.kt
+++ b/domain/src/main/java/com/takseha/domain/usecase/commit/UpdateCommitCommentUseCase.kt
@@ -1,0 +1,14 @@
+package com.takseha.domain.usecase.commit
+
+import com.takseha.domain.model.commit.PostCommitCommentParam
+import com.takseha.domain.repository.CommitRepository
+
+/**
+ * 커밋 댓글 수정
+ */
+class UpdateCommitCommentUseCase(
+    private val commitRepository: CommitRepository
+) {
+    suspend operator fun invoke(commitId: Int, postCommitCommentParam: PostCommitCommentParam) =
+        commitRepository.updateCommitComment(commitId, postCommitCommentParam)
+}


### PR DESCRIPTION
## ☝️연관된 이슈

<b>#49</b>

## ✌️구현 내용
> 📌 요약: 커밋 관련 usecase 구현

- `GetCommitDetailUseCase`
: 커밋 상세 정보 조회

- `RespondToCommitUseCase`
: 커밋 승인/반려

- `GetCommitCommentsUseCase`
: 커밋 댓글 리스트 조회

- `PostCommitCommentUseCase`
: 커밋 댓글 등록

- `UpdateCommitCommentUseCase`
: 커밋 댓글 수정

- `DeleteCommitCommentUseCase`
: 커밋 댓글 삭제
