### PR TITLE
Feat(#51): [domain] usecase 정의 - 마이스터디 세팅 관련

### DIFF
--- a/domain/src/main/java/com/takseha/domain/repository/MyStudyRepository.kt
+++ b/domain/src/main/java/com/takseha/domain/repository/MyStudyRepository.kt
@@ -40,6 +40,7 @@ interface MyStudyRepository {
     suspend fun deleteMyStudyComment(studyId: Int, studyCommentId: Int)
 
     /** 스터디 신청자 목록 확인 */
+    suspend fun getStudyApplications(cursorIdx: Long?, limit: Long, studyId: Int): List<StudyApplicant>?
     suspend fun fetchStudyApplications(cursorIdx: Long?, limit: Long, studyId: Int): List<StudyApplicant>
 
     /** 스터디 신청 승인/거절 */

--- a/domain/src/main/java/com/takseha/domain/usecase/mystudysettings/DeleteStudyUseCase.kt
+++ b/domain/src/main/java/com/takseha/domain/usecase/mystudysettings/DeleteStudyUseCase.kt
@@ -1,0 +1,12 @@
+package com.takseha.domain.usecase.mystudysettings
+
+import com.takseha.domain.repository.MyStudyRepository
+
+/**
+ * 스터디 삭제
+ */
+class DeleteStudyUseCase(
+    private val myStudyRepository: MyStudyRepository
+) {
+    suspend operator fun invoke(studyId: Int) = myStudyRepository.deleteStudy(studyId)
+}

--- a/domain/src/main/java/com/takseha/domain/usecase/mystudysettings/EndStudyUseCase.kt
+++ b/domain/src/main/java/com/takseha/domain/usecase/mystudysettings/EndStudyUseCase.kt
@@ -1,0 +1,12 @@
+package com.takseha.domain.usecase.mystudysettings
+
+import com.takseha.domain.repository.MyStudyRepository
+
+/**
+ * 스터디 종료
+ */
+class EndStudyUseCase(
+    private val myStudyRepository: MyStudyRepository
+) {
+    suspend operator fun invoke(studyId: Int) = myStudyRepository.endStudy(studyId)
+}

--- a/domain/src/main/java/com/takseha/domain/usecase/mystudysettings/GetStudyApplicationsUseCase.kt
+++ b/domain/src/main/java/com/takseha/domain/usecase/mystudysettings/GetStudyApplicationsUseCase.kt
@@ -1,0 +1,17 @@
+package com.takseha.domain.usecase.mystudysettings
+
+import com.takseha.domain.repository.MyStudyRepository
+import com.takseha.domain.utils.getOrFetch
+
+/**
+ * 스터디 신청자 리스트 조회
+ * : Room 먼저 조회(get) -> null이면 서버에서 조회(fetch)
+ */
+class GetStudyApplicationsUseCase(
+    private val myStudyRepository: MyStudyRepository
+) {
+    suspend operator fun invoke(cursorIdx: Long? = null, limit: Long = 10, studyId: Int) = getOrFetch(
+        get = { myStudyRepository.getStudyApplications(cursorIdx, limit, studyId) },
+        fetch = { myStudyRepository.fetchStudyApplications(cursorIdx, limit, studyId) }
+    )
+}

--- a/domain/src/main/java/com/takseha/domain/usecase/mystudysettings/RespondToStudyApplicationUseCase.kt
+++ b/domain/src/main/java/com/takseha/domain/usecase/mystudysettings/RespondToStudyApplicationUseCase.kt
@@ -1,0 +1,13 @@
+package com.takseha.domain.usecase.mystudysettings
+
+import com.takseha.domain.repository.MyStudyRepository
+
+/**
+ * 스터디 신청 승인/거절
+ */
+class RespondToStudyApplicationUseCase(
+    private val myStudyRepository: MyStudyRepository
+) {
+    suspend operator fun invoke(studyId: Int, applicantId: Int, isAccepted: Boolean) =
+        myStudyRepository.respondToStudyApplication(studyId, applicantId, isAccepted)
+}

--- a/domain/src/main/java/com/takseha/domain/usecase/mystudysettings/WithdrawFromStudyUseCase.kt
+++ b/domain/src/main/java/com/takseha/domain/usecase/mystudysettings/WithdrawFromStudyUseCase.kt
@@ -1,0 +1,12 @@
+package com.takseha.domain.usecase.mystudysettings
+
+import com.takseha.domain.repository.MyStudyRepository
+
+/**
+ * 스터디 탈퇴
+ */
+class WithdrawFromStudyUseCase(
+    private val myStudyRepository: MyStudyRepository
+) {
+    suspend operator fun invoke(studyId: Int) = myStudyRepository.withdrawFromStudy(studyId)
+}


### PR DESCRIPTION
## ☝️연관된 이슈

<b>#51</b>

## ✌️구현 내용
> 📌 요약: 마이스터디 세팅 관련 usecase 구현

- `GetStudyApplicationsUseCase`
: 스터디 신청자 리스트 조회

- `RespondToStudyApplicationUseCase`
: 스터디 신청 승인/거절

- `WithdrawFromStudyUseCase`
: 스터디 탈퇴

- `EndStudyUseCase`
: 스터디 종료

- `DeleteStudyUseCase`
: 스터디 삭제
