### PR TITLE
Feat(#55): [domain] usecase 정의 - 프로필 관련

### DIFF
--- a/domain/src/main/java/com/takseha/domain/repository/ProfileRepository.kt
+++ b/domain/src/main/java/com/takseha/domain/repository/ProfileRepository.kt
@@ -14,15 +14,13 @@ interface ProfileRepository {
     suspend fun updateUserInfo(updateUserInfoParam: UpdateUserInfoParam)
     /** 푸시 알림 사용 여부 업데이트 */
     suspend fun updatePushNotificationEnabled(isEnabled: Boolean)
-    /** 닉네임 중복 체크 */
-    suspend fun checkNicknameDuplication(nickname: String): Boolean
 
     /** 마이커밋 리스트 조회 */
-    suspend fun getMyCommits(cursorIdx: Long?, limit: Long, studyId: Int?): List<CommitSummary>
+    suspend fun getMyCommits(cursorIdx: Long?, limit: Long, studyId: Int?): List<CommitSummary>?
     suspend fun fetchMyCommits(cursorIdx: Long?, limit: Long, studyId: Int?): List<CommitSummary>
 
     /** 스터디 북마크 리스트 조회 */
-    suspend fun getStudyBookmarks(cursorIdx: Long?, limit: Long): List<StudyBookmark>
+    suspend fun getStudyBookmarks(cursorIdx: Long?, limit: Long): List<StudyBookmark>?
     suspend fun fetchStudyBookmarks(cursorIdx: Long?, limit: Long): List<StudyBookmark>
 
     /** 스터디 북마크 업데이트 */

--- a/domain/src/main/java/com/takseha/domain/usecase/profile/DeleteAccountUseCase.kt
+++ b/domain/src/main/java/com/takseha/domain/usecase/profile/DeleteAccountUseCase.kt
@@ -1,0 +1,12 @@
+package com.takseha.domain.usecase.profile
+
+import com.takseha.domain.repository.AuthRepository
+
+/**
+ * 회원탈퇴
+ */
+class DeleteAccountUseCase(
+    private val authRepository: AuthRepository
+) {
+    suspend operator fun invoke(withdrawalReason: String) = authRepository.deleteAccount(withdrawalReason)
+}

--- a/domain/src/main/java/com/takseha/domain/usecase/profile/GetMyCommitsUseCase.kt
+++ b/domain/src/main/java/com/takseha/domain/usecase/profile/GetMyCommitsUseCase.kt
@@ -1,0 +1,18 @@
+package com.takseha.domain.usecase.profile
+
+import com.takseha.domain.repository.ProfileRepository
+import com.takseha.domain.utils.getOrFetch
+
+/**
+ * 마이커밋 리스트 조회
+ * : Room 먼저 조회(get) -> null이면 서버에서 조회(fetch)
+ */
+class GetMyCommitsUseCase(
+    private val profileRepository: ProfileRepository
+) {
+    suspend operator fun invoke(cursorIdx: Long? = null, limit: Long = 3, studyId: Int) =
+        getOrFetch(
+            get = { profileRepository.getMyCommits(cursorIdx, limit, studyId) },
+            fetch = { profileRepository.fetchMyCommits(cursorIdx, limit, studyId) }
+        )
+}

--- a/domain/src/main/java/com/takseha/domain/usecase/profile/GetStudyBookmarksUseCase.kt
+++ b/domain/src/main/java/com/takseha/domain/usecase/profile/GetStudyBookmarksUseCase.kt
@@ -1,0 +1,18 @@
+package com.takseha.domain.usecase.profile
+
+import com.takseha.domain.repository.ProfileRepository
+import com.takseha.domain.utils.getOrFetch
+
+/**
+ * 스터디 북마크 리스트 조회
+ * : Room 먼저 조회(get) -> null이면 서버에서 조회(fetch)
+ */
+class GetStudyBookmarksUseCase(
+    private val profileRepository: ProfileRepository
+) {
+    suspend operator fun invoke(cursorIdx: Long? = null, limit: Long = 3) =
+        getOrFetch(
+            get = { profileRepository.getStudyBookmarks(cursorIdx, limit) },
+            fetch = { profileRepository.fetchStudyBookmarks(cursorIdx, limit) }
+        )
+}

--- a/domain/src/main/java/com/takseha/domain/usecase/profile/SignOutUseCase.kt
+++ b/domain/src/main/java/com/takseha/domain/usecase/profile/SignOutUseCase.kt
@@ -1,0 +1,12 @@
+package com.takseha.domain.usecase.profile
+
+import com.takseha.domain.repository.AuthRepository
+
+/**
+ * 로그아웃
+ */
+class SignOutUseCase(
+    private val authRepository: AuthRepository
+) {
+    suspend operator fun invoke() = authRepository.signOut()
+}

--- a/domain/src/main/java/com/takseha/domain/usecase/profile/UpdatePushNotificationEnabled.kt
+++ b/domain/src/main/java/com/takseha/domain/usecase/profile/UpdatePushNotificationEnabled.kt
@@ -1,0 +1,13 @@
+package com.takseha.domain.usecase.profile
+
+import com.takseha.domain.repository.ProfileRepository
+
+/**
+ * 푸시 알림 사용 여부 수정
+ */
+class UpdatePushNotificationEnabled(
+    private val profileRepository: ProfileRepository
+) {
+    suspend operator fun invoke(isEnabled: Boolean) =
+        profileRepository.updatePushNotificationEnabled(isEnabled)
+}

--- a/domain/src/main/java/com/takseha/domain/usecase/profile/UpdateUserInfoUseCase.kt
+++ b/domain/src/main/java/com/takseha/domain/usecase/profile/UpdateUserInfoUseCase.kt
@@ -1,0 +1,14 @@
+package com.takseha.domain.usecase.profile
+
+import com.takseha.domain.model.profile.UpdateUserInfoParam
+import com.takseha.domain.repository.ProfileRepository
+
+/**
+ * 프로필 정보 수정
+ */
+class UpdateUserInfoUseCase(
+    private val profileRepository: ProfileRepository
+) {
+    suspend operator fun invoke(updateUserInfoParam: UpdateUserInfoParam) =
+        profileRepository.updateUserInfo(updateUserInfoParam)
+}


### PR DESCRIPTION
## ☝️연관된 이슈

<b>#55</b>

## ✌️구현 내용
> 📌 요약: 프로필 관련 usecase 구현

- `GetMyCommitsUseCase`
: 마이커밋 리스트 조회

- `GetStudyBookmarksUseCase`
: 스터디 북마크 리스트 조회

- `UpdatePushNotificationEnabled`
: 푸시 알림 사용 여부 수정

- `UpdateUserInfoUseCase`
: 프로필 정보 수정

- `SignOutUseCase`
: 로그아웃

- `DeleteAccountUseCase`
: 회원탈퇴
