### PR TITLE
Feat(#59): [data] ApiService 구현

### DIFF
--- a/data/src/main/java/com/takseha/data/source/remote/api/CommitService.kt
+++ b/data/src/main/java/com/takseha/data/source/remote/api/CommitService.kt
@@ -1,0 +1,71 @@
+package com.takseha.data.source.remote.api
+
+import com.takseha.data.source.remote.dto.commit.request.CommitCommentRequest
+import com.takseha.data.source.remote.dto.commit.request.CommitRejectRequest
+import com.takseha.data.source.remote.dto.commit.response.CommitDetailResponse
+import com.takseha.data.source.remote.dto.mystudy.response.CommentResponse
+import com.takseha.data.source.remote.dto.profile.response.MyCommitsResponse
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.DELETE
+import retrofit2.http.GET
+import retrofit2.http.PATCH
+import retrofit2.http.POST
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+/**
+ * 커밋 관련 api 정의 인터페이스
+ */
+interface CommitService {
+    @GET("/commits")
+    suspend fun fetchMyCommits(
+        @Query("studyInfoId") studyId: Int?,
+        @Query("cursorIdx") cursorIdx: Long?,
+        @Query("limit") limit: Long
+    ): Response<MyCommitsResponse>
+
+    @GET("/commits/{commitId}")
+    suspend fun fetchCommitDetail(
+        @Path("commitId") commitId: Int,
+        @Query("studyInfoId") studyId: Int
+    ): Response<CommitDetailResponse>
+
+    @GET("/commits/{commitId}/approve")
+    suspend fun approveCommit(
+        @Path("commitId") commitId: Int,
+        @Query("studyInfoId") studyId: Int
+    ): Response<Void>
+
+    @POST("/commits/{commitId}/reject")
+    suspend fun rejectCommit(
+        @Path("commitId") commitId: Int,
+        @Query("studyInfoId") studyId: Int,
+        @Body request: CommitRejectRequest
+    ): Response<Void>
+
+    @GET("/commits/{commitId}/comments")
+    suspend fun fetchCommitComments(
+        @Path("commitId") commitId: Int,
+        @Query("studyInfoId") studyId: Int
+    ): Response<List<CommentResponse>>
+
+    @POST("/commits/{commitId}/comments")
+    suspend fun postCommitComment(
+        @Path("commitId") commitId: Int,
+        @Body request: CommitCommentRequest
+    ): Response<Void>
+
+    @PATCH("/commits/{commitId}/comments/{commentId}")
+    suspend fun updateCommitComment(
+        @Path("commitId") commitId: Int,
+        @Path("commentId") commentId: Int,
+        @Body request: CommitCommentRequest
+    ): Response<Void>
+
+    @DELETE("/commits/{commitId}/comments/{commentId}")
+    suspend fun deleteCommitComment(
+        @Path("commitId") commitId: Int,
+        @Path("commentId") commentId: Int
+    ): Response<Void>
+}

--- a/data/src/main/java/com/takseha/data/source/remote/api/PlainAuthService.kt
+++ b/data/src/main/java/com/takseha/data/source/remote/api/PlainAuthService.kt
@@ -1,0 +1,31 @@
+package com.takseha.data.source.remote.api
+
+import com.takseha.data.source.remote.dto.auth.request.AdminSignInRequest
+import com.takseha.data.source.remote.dto.auth.response.SignInPageInfoResponse
+import com.takseha.data.source.remote.dto.auth.response.TokenInfoResponse
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+/**
+ * 인증 관련 api 정의 인터페이스 (header 토큰 X)
+ */
+interface PlainAuthService {
+    @GET("/auth/loginPage")
+    suspend fun fetchSignInPages(): Response<SignInPageInfoResponse>
+
+    @GET("/auth/{platformType}/login")
+    suspend fun signIn(
+        @Path("platformType") platformType: String,
+        @Query("code") code: String,
+        @Query("state") state: String
+    ): Response<TokenInfoResponse>
+
+    @POST("/auth/admin")
+    suspend fun signInAsAdmin(
+        @Body request: AdminSignInRequest
+    ): Response<TokenInfoResponse>
+}

--- a/data/src/main/java/com/takseha/data/source/remote/api/ProfileService.kt
+++ b/data/src/main/java/com/takseha/data/source/remote/api/ProfileService.kt
@@ -1,0 +1,28 @@
+package com.takseha.data.source.remote.api
+
+import com.takseha.data.source.remote.dto.profile.request.UserInfoUpdateRequest
+import com.takseha.data.source.remote.dto.profile.response.UserInfoResponse
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.Path
+
+/**
+ * 프로필 관련 api 정의 인터페이스
+ */
+interface ProfileService {
+    @GET("/auth/info")
+    suspend fun fetchUserInfo(
+    ): Response<UserInfoResponse>
+
+    @GET("/auth/update/pushAlarmYn/{pushAlarmEnable}")
+    suspend fun updatePushNotificationEnabled(
+        @Path("pushAlarmEnable") isEnabled: Boolean
+    ): Response<Void>
+
+    @POST("/auth/update")
+    suspend fun updateUserInfo(
+        @Body request: UserInfoUpdateRequest
+    ): Response<Void>
+}

--- a/data/src/main/java/com/takseha/data/source/remote/api/SecureAuthService.kt
+++ b/data/src/main/java/com/takseha/data/source/remote/api/SecureAuthService.kt
@@ -1,0 +1,37 @@
+package com.takseha.data.source.remote.api
+
+import com.takseha.data.source.remote.dto.auth.request.CheckNicknameDuplicationRequest
+import com.takseha.data.source.remote.dto.auth.request.SignUpRequest
+import com.takseha.data.source.remote.dto.auth.response.TokenInfoResponse
+import com.takseha.data.source.remote.dto.study.request.MessageRequest
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+/**
+ * 인증 관련 api 정의 인터페이스 (header 토큰 O)
+ */
+interface SecureAuthService {
+    @POST("/auth/register")
+    suspend fun signUp(
+        @Body request: SignUpRequest
+    ): Response<TokenInfoResponse>
+
+    @POST("/auth/reissue")
+    suspend fun reissueTokens(
+    ): Response<TokenInfoResponse>
+
+    @POST("/auth/logout")
+    suspend fun signOut(
+    ): Response<Void>
+
+    @POST("/auth/delete")
+    suspend fun deleteAccount(
+        @Body request: MessageRequest
+    ): Response<Void>
+
+    @POST("/auth/check-nickname")
+    suspend fun checkNicknameDuplication(
+        @Body request: CheckNicknameDuplicationRequest
+    ): Response<Void>
+}

--- a/data/src/main/java/com/takseha/data/source/remote/api/StudyService.kt
+++ b/data/src/main/java/com/takseha/data/source/remote/api/StudyService.kt
@@ -1,0 +1,139 @@
+package com.takseha.data.source.remote.api
+
+import com.takseha.data.source.remote.dto.mystudy.request.CommentRequest
+import com.takseha.data.source.remote.dto.mystudy.response.CategoriesResponse
+import com.takseha.data.source.remote.dto.mystudy.response.StudyCommentsResponse
+import com.takseha.data.source.remote.dto.mystudy.response.StudyMemberResponse
+import com.takseha.data.source.remote.dto.profile.response.StudyBookmarkResponse
+import com.takseha.data.source.remote.dto.profile.response.StudyBookmarksResponse
+import com.takseha.data.source.remote.dto.study.request.CheckRepoNameDuplicationRequest
+import com.takseha.data.source.remote.dto.study.request.CreateStudyRequest
+import com.takseha.data.source.remote.dto.study.request.MessageRequest
+import com.takseha.data.source.remote.dto.study.response.CategoryResponse
+import com.takseha.data.source.remote.dto.study.response.StudiesResponse
+import com.takseha.data.source.remote.dto.study.response.StudyCountResponse
+import com.takseha.data.source.remote.dto.study.response.StudyDetailResponse
+import com.takseha.data.source.remote.dto.study.response.StudyRankResponse
+import com.takseha.data.source.remote.dto.todo.response.TodoSummaryResponse
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.DELETE
+import retrofit2.http.GET
+import retrofit2.http.PATCH
+import retrofit2.http.POST
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+/**
+ * 스터디 관련 api 정의 인터페이스
+ */
+interface StudyService {
+    @GET("/study/")
+    suspend fun fetchStudies(
+        @Query("cursorIdx") cursorIdx: Long?,
+        @Query("limit") limit: Long,
+        @Query("sortBy") sortBy: String,
+        @Query("myStudy") myStudy: Boolean
+    ): Response<StudiesResponse>
+
+    @GET("/study/count")
+    suspend fun fetchStudyCount(
+        @Query("myStudy") myStudy: Boolean
+    ): Response<StudyCountResponse>
+
+    @GET("/category/")
+    suspend fun fetchAllCategories(
+    ): Response<List<CategoryResponse>>
+
+    @GET("/category/{studyInfoId}")
+    suspend fun fetchStudyCategories(
+        @Path("studyInfoId") studyId: Int,
+        @Query("cursorIdx") cursorIdx: Long?,
+        @Query("limit") limit: Int
+    ): Response<CategoriesResponse>
+
+    @GET("/study/rank/{studyInfoId}")
+    suspend fun fetchStudyRankAndScore(
+        @Path("studyInfoId") studyId: Int
+    ): Response<StudyRankResponse>
+
+    @GET("/bookmarks")
+    suspend fun fetchStudyBookmarks(
+        @Query("cursorIdx") cursorIdx: Long?,
+        @Query("limit") limit: Long
+    ): Response<StudyBookmarksResponse>
+
+    @GET("/bookmarks/study/{studyInfoId}")
+    suspend fun toggleStudyBookmark(
+        @Path("studyInfoId") studyId: Int
+    ): Response<Void>
+
+    @GET("/bookmarks/study/{studyInfoId}/my-bookmark")
+    suspend fun fetchStudyBookmark(
+        @Path("studyInfoId") studyId: Int
+    ): Response<StudyBookmarkResponse>
+
+    @POST("/study/check-name")
+    suspend fun checkRepoNameDuplication(
+        @Body request: CheckRepoNameDuplicationRequest
+    ): Response<Void>
+
+    @POST("/study/")
+    suspend fun createStudy(
+        @Body request: CreateStudyRequest
+    ): Response<Void>
+
+    @GET("/study/{studyInfoId}/todo/progress")
+    suspend fun fetchNearestDeadlineTodo(
+        @Path("studyInfoId") studyId: Int
+    ): Response<TodoSummaryResponse>
+
+    @GET("/study/{studyInfoId}")
+    suspend fun fetchStudyDetail(
+        @Path("studyInfoId") studyId: Int
+    ): Response<StudyDetailResponse>
+
+    @POST("/member/{studyInfoId}/apply")
+    suspend fun submitStudyApplication(
+        @Path("studyInfoId") studyId: Int,
+        @Query("joinCode") joinCode: String,
+        @Body request: MessageRequest
+    ): Response<Void>
+
+    @DELETE("/member/{studyInfoId}/apply")
+    suspend fun cancelStudyApplication(
+        @Path("studyInfoId") studyId: Int
+    ): Response<Void>
+
+    @GET("/member/{studyInfoId}")
+    suspend fun fetchStudyMembers(
+        @Path("studyInfoId") studyId: Int,
+        @Query("orderByScore") orderByScore: Boolean?
+    ): Response<List<StudyMemberResponse>>
+
+    @GET("/study/{studyInfoId}/comments")
+    suspend fun fetchMyStudyComments(
+        @Path("studyInfoId") studyId: Int,
+        @Query("cursorIdx") cursorIdx: Long?,
+        @Query("limit") limit: Long
+    ): Response<StudyCommentsResponse>
+
+    @POST("/study/{studyInfoId}/comment")
+    suspend fun postMyStudyComment(
+        @Path("studyInfoId") studyId: Int,
+        @Body request: CommentRequest
+    ): Response<Void>
+
+    @PATCH("/study/{studyInfoId}/comment/{studyCommentId}")
+    suspend fun updateMyStudyComment(
+        @Path("studyInfoId") studyId: Int,
+        @Path("studyCommentId") studyCommentId: Int,
+        @Body request: CommentRequest
+    ): Response<Void>
+
+    @DELETE("/study/{studyInfoId}/comment/{studyCommentId}")
+    suspend fun deleteMyStudyComment(
+        @Path("studyInfoId") studyId: Int,
+        @Path("studyCommentId") studyCommentId: Int
+    ): Response<Void>
+}

--- a/data/src/main/java/com/takseha/data/source/remote/api/StudySettingService.kt
+++ b/data/src/main/java/com/takseha/data/source/remote/api/StudySettingService.kt
@@ -1,0 +1,52 @@
+package com.takseha.data.source.remote.api
+
+import com.takseha.data.source.remote.dto.mystudy.response.StudyApplicantsResponse
+import com.takseha.data.source.remote.dto.study.request.MessageRequest
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.DELETE
+import retrofit2.http.GET
+import retrofit2.http.PATCH
+import retrofit2.http.POST
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+/**
+ * 스터디 세팅 관련 api 정의 인터페이스
+ */
+interface StudySettingService {
+    @DELETE("/study/{studyInfoId}")
+    suspend fun deleteStudy(
+        @Path("studyInfoId") studyId: Int
+    ): Response<Void>
+
+    @DELETE("/study/{studyInfoId}/close")
+    suspend fun endStudy(
+        @Path("studyInfoId") studyId: Int
+    ): Response<Void>
+
+    @GET("/member/{studyInfoId}/apply")
+    suspend fun fetchStudyApplications(
+        @Path("studyInfoId") studyId: Int,
+        @Query("cursorIdx") cursorIdx: Long?,
+        @Query("limit") limit: Long,
+    ): Response<StudyApplicantsResponse>
+
+    @POST("/member/{studyInfoId}/notify/leader")
+    suspend fun notifyToLeader(
+        @Path("studyInfoId") studyId: Int,
+        @Body request: MessageRequest
+    ): Response<Void>
+
+    @PATCH("/member/{studyInfoId}/apply/{applyUserId}")
+    suspend fun respondToStudyApplication(
+        @Path("studyInfoId") studyId: Int,
+        @Path("applyUserId") applicantId: Int,
+        @Query("approve") isAccepted: Boolean
+    ): Response<Void>
+
+    @PATCH("/member/{studyInfoId}/withdrawal")
+    suspend fun withdrawFromStudy(
+        @Path("studyInfoId") studyId: Int
+    ): Response<Void>
+}

--- a/data/src/main/java/com/takseha/data/source/remote/api/TodoService.kt
+++ b/data/src/main/java/com/takseha/data/source/remote/api/TodoService.kt
@@ -1,0 +1,50 @@
+package com.takseha.data.source.remote.api
+
+import com.takseha.data.source.remote.dto.todo.request.TodoCreateRequest
+import com.takseha.data.source.remote.dto.todo.response.TodoListResponse
+import com.takseha.data.source.remote.dto.todo.response.TodoResponse
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.DELETE
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.PUT
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+/**
+ * 투두 관련 api 정의 인터페이스
+ */
+interface TodoService {
+    @GET("/study/{studyInfoId}/todo")
+    suspend fun fetchTodoList(
+        @Path("studyInfoId") studyId: Int,
+        @Query("cursorIdx") cursorIdx: Long?,
+        @Query("limit") limit: Long,
+    ): Response<TodoListResponse>
+
+    @GET("/study/{studyInfoId}/todo/{todoId}")
+    suspend fun fetchTodoDetail(
+        @Path("studyInfoId") studyId: Int,
+        @Path("todoId") todoId: Int,
+    ): Response<TodoResponse>
+
+    @POST("/study/{studyInfoId}/todo")
+    suspend fun createTodo(
+        @Path("studyInfoId") studyId: Int,
+        @Body request: TodoCreateRequest
+    ): Response<Void>
+
+    @PUT("/study/{studyInfoId}/todo/{todoId}")
+    suspend fun updateTodo(
+        @Path("studyInfoId") studyId: Int,
+        @Path("todoId") todoId: Int,
+        @Body request: TodoCreateRequest
+    ): Response<Void>
+
+    @DELETE("/study/{studyInfoId}/todo/{todoId}")
+    suspend fun deleteTodo(
+        @Path("studyInfoId") studyId: Int,
+        @Path("todoId") todoId: Int
+    ): Response<Void>
+}

--- a/data/src/main/java/com/takseha/data/source/remote/dto/auth/response/TokenInfoResponse.kt
+++ b/data/src/main/java/com/takseha/data/source/remote/dto/auth/response/TokenInfoResponse.kt
@@ -4,7 +4,7 @@ package com.takseha.data.source.remote.dto.auth.response
 import com.google.gson.annotations.SerializedName
 import com.takseha.domain.model.auth.common.Role
 
-data class TokenResponse(
+data class TokenInfoResponse(
     @SerializedName("access_token")
     val accessToken: String,
     @SerializedName("refresh_token")

--- a/domain/src/main/java/com/takseha/domain/model/auth/TokenInfo.kt
+++ b/domain/src/main/java/com/takseha/domain/model/auth/TokenInfo.kt
@@ -3,7 +3,7 @@ package com.takseha.domain.model.auth
 import com.takseha.domain.model.auth.common.Role
 import com.takseha.domain.model.auth.common.Token
 
-data class AuthResult(
+data class TokenInfo(
     val tokens: Token,
-    val role: Role
+    val role: Role?
 )

--- a/domain/src/main/java/com/takseha/domain/repository/AuthRepository.kt
+++ b/domain/src/main/java/com/takseha/domain/repository/AuthRepository.kt
@@ -1,22 +1,22 @@
 package com.takseha.domain.repository
 
-import com.takseha.domain.model.auth.AuthResult
+import com.takseha.domain.model.auth.TokenInfo
 import com.takseha.domain.model.auth.SignInPageInfo
 import com.takseha.domain.model.auth.SignUpParam
 
 interface AuthRepository {
     /** 로그인 페이지 url 조회 */
-    suspend fun getLoginPages(): SignInPageInfo
-    suspend fun fetchLoginPages(): SignInPageInfo
+    suspend fun getSignInPages(): SignInPageInfo
+    suspend fun fetchSignInPages(): SignInPageInfo
 
     /** 사용자 세션이 유효한 지 확인 */
     suspend fun isUserLoggedIn(): Boolean
 
     /** 로그인 */
-    suspend fun signIn(platformType: String, code: String, state: String): AuthResult
+    suspend fun signIn(platformType: String, code: String, state: String): TokenInfo
 
     /** 회원가입 */
-    suspend fun signUp(signUpParam: SignUpParam): AuthResult
+    suspend fun signUp(signUpParam: SignUpParam): TokenInfo
     /** 닉네임 중복 여부 확인 */
     suspend fun checkNicknameDuplication(nickname: String): Boolean
 

--- a/domain/src/main/java/com/takseha/domain/usecase/signin/GetSignInPagesUseCase.kt
+++ b/domain/src/main/java/com/takseha/domain/usecase/signin/GetSignInPagesUseCase.kt
@@ -5,8 +5,8 @@ import com.takseha.domain.repository.AuthRepository
 /**
  * 로그인 페이지 url 조회
  */
-class GetLoginPagesUseCase(
+class GetSignInPagesUseCase(
     private val authRepository: AuthRepository
 ) {
-    suspend operator fun invoke() = authRepository.fetchLoginPages()
+    suspend operator fun invoke() = authRepository.fetchSignInPages()
 }


### PR DESCRIPTION
## ☝️연관된 이슈

<b>#59</b>

## ✌️구현 내용
> 📌 요약: 기능 별 ApiServices 정의

- `PlainAuthService`
: 인증 관련 api 정의 인터페이스 (header 토큰 X)

- `SecureAuthService`
: 인증 관련 api 정의 인터페이스 (header 토큰 O)

- `StudyService`
: 스터디 관련 api 정의 인터페이스

- `StudySettingService`
: 스터디 세팅 관련 api 정의 인터페이스

- `TodoService`
: 투두 관련 api 정의 인터페이스

- `CommitService`
: 커밋 관련 api 정의 인터페이스

- `NotificationService`
: 알림 관련 api 정의 인터페이스

- `ProfileService`
: 프로필 관련 api 정의 인터페이스
