### PR TITLE
Feat(#61): [data] entity 구현 - 마이스터디 목록/홈 화면 관련

### DIFF
--- a/data/src/main/java/com/takseha/data/source/local/entity/mystudy/MyStudyCategoryEntity.kt
+++ b/data/src/main/java/com/takseha/data/source/local/entity/mystudy/MyStudyCategoryEntity.kt
@@ -4,8 +4,11 @@ import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 
-@Entity(tableName = "MyStudyCategory")
+@Entity(
+    tableName = "MyStudyCategory",
+    primaryKeys = ["studyId", "category"]
+)
 class MyStudyCategoryEntity(
-    @PrimaryKey val studyId: Int,
+    @ColumnInfo("studyId") val studyId: Int,
     @ColumnInfo("category") val category: String
 )

--- a/data/src/main/java/com/takseha/data/source/local/entity/mystudy/MyStudyCategoryEntity.kt
+++ b/data/src/main/java/com/takseha/data/source/local/entity/mystudy/MyStudyCategoryEntity.kt
@@ -1,0 +1,11 @@
+package com.takseha.data.source.local.entity.mystudy
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "MyStudyCategory")
+class MyStudyCategoryEntity(
+    @PrimaryKey val studyId: Int,
+    @ColumnInfo("category") val category: String
+)

--- a/data/src/main/java/com/takseha/data/source/local/entity/mystudy/MyStudyCommentEntity.kt
+++ b/data/src/main/java/com/takseha/data/source/local/entity/mystudy/MyStudyCommentEntity.kt
@@ -1,14 +1,16 @@
 package com.takseha.data.source.local.entity.mystudy
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
+import androidx.room.PrimaryKey
 
 @Entity(tableName = "MyStudyComment")
 data class MyStudyCommentEntity (
-    val id: Int,
-    val studyId: Int,
-    val writerName: String,
-    val writerProfileUrl: String,
-    val content: String,
-    val createdAt: String,
-    val isMyComment: Boolean
+    @PrimaryKey val id: Int,
+    @ColumnInfo("studyId") val studyId: Int,
+    @ColumnInfo("writerName") val writerName: String,
+    @ColumnInfo("writerProfileUrl") val writerProfileUrl: String,
+    @ColumnInfo("content") val content: String,
+    @ColumnInfo("createdAt") val createdAt: String,
+    @ColumnInfo("isMyComment") val isMyComment: Boolean
 )

--- a/data/src/main/java/com/takseha/data/source/local/entity/mystudy/MyStudyCommentEntity.kt
+++ b/data/src/main/java/com/takseha/data/source/local/entity/mystudy/MyStudyCommentEntity.kt
@@ -1,0 +1,14 @@
+package com.takseha.data.source.local.entity.mystudy
+
+import androidx.room.Entity
+
+@Entity(tableName = "MyStudyComment")
+data class MyStudyCommentEntity (
+    val id: Int,
+    val studyId: Int,
+    val writerName: String,
+    val writerProfileUrl: String,
+    val content: String,
+    val createdAt: String,
+    val isMyComment: Boolean
+)

--- a/data/src/main/java/com/takseha/data/source/local/entity/mystudy/MyStudyDetailEntity.kt
+++ b/data/src/main/java/com/takseha/data/source/local/entity/mystudy/MyStudyDetailEntity.kt
@@ -1,0 +1,17 @@
+package com.takseha.data.source.local.entity.mystudy
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "MyStudyDetail")
+class MyStudyDetailEntity(
+    @PrimaryKey val id: Int,
+    @ColumnInfo("studyName") val studyName: String,
+    @ColumnInfo("info") val info: String,
+    @ColumnInfo("cycle") val cycle: String,
+    @ColumnInfo("status") val status: String,
+    @ColumnInfo("studyProfileUrl") val studyProfileUrl: String,
+    @ColumnInfo("isLeader") val isLeader: Boolean,
+    @ColumnInfo("githubRepoUrl") val githubRepoUrl: String
+)

--- a/data/src/main/java/com/takseha/data/source/local/entity/mystudy/MyStudyMemberEntity.kt
+++ b/data/src/main/java/com/takseha/data/source/local/entity/mystudy/MyStudyMemberEntity.kt
@@ -1,0 +1,13 @@
+package com.takseha.data.source.local.entity.mystudy
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "MyStudyMember")
+class MyStudyMemberEntity(
+    @PrimaryKey val studyId: Int,
+    @ColumnInfo("userName") val userName: String,
+    @ColumnInfo("profileUrl") val profileUrl: String,
+    @ColumnInfo("point") val point: Int
+)

--- a/data/src/main/java/com/takseha/data/source/local/entity/mystudy/MyStudyMemberEntity.kt
+++ b/data/src/main/java/com/takseha/data/source/local/entity/mystudy/MyStudyMemberEntity.kt
@@ -4,9 +4,11 @@ import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 
-@Entity(tableName = "MyStudyMember")
+@Entity(tableName = "MyStudyMember",
+    primaryKeys = ["studyId", "userName"]
+)
 class MyStudyMemberEntity(
-    @PrimaryKey val studyId: Int,
+    @ColumnInfo("studyId") val studyId: Int,
     @ColumnInfo("userName") val userName: String,
     @ColumnInfo("profileUrl") val profileUrl: String,
     @ColumnInfo("point") val point: Int

--- a/data/src/main/java/com/takseha/data/source/local/entity/mystudy/MyStudySummaryEntity.kt
+++ b/data/src/main/java/com/takseha/data/source/local/entity/mystudy/MyStudySummaryEntity.kt
@@ -1,0 +1,14 @@
+package com.takseha.data.source.local.entity.mystudy
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "MyStudySummary")
+class MyStudySummaryEntity(
+    @PrimaryKey val id: Int,
+    @ColumnInfo("studyName") val studyName: String,
+    @ColumnInfo("score") val score: Int,
+    @ColumnInfo("studyProfileUrl") val studyProfileUrl: String,
+    @ColumnInfo("isLeader") val isLeader: Boolean
+)

--- a/data/src/main/java/com/takseha/data/source/local/entity/mystudy/TodoSummaryEntity.kt
+++ b/data/src/main/java/com/takseha/data/source/local/entity/mystudy/TodoSummaryEntity.kt
@@ -1,0 +1,17 @@
+package com.takseha.data.source.local.entity.mystudy
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import com.takseha.domain.model.mystudy.TodoStatus
+
+@Entity(tableName = "TodoSummary")
+class TodoSummaryEntity(
+    @PrimaryKey val id: Int,
+    @ColumnInfo("studyId") val studyId: Int,
+    @ColumnInfo("title") val title: String,
+    @ColumnInfo("deadline") val deadline: String,
+    @ColumnInfo("completeMemberCount") val completeMemberCount: Int,
+    @ColumnInfo("totalMemberCount") val totalMemberCount: Int,
+    @ColumnInfo("myStatus") val myStatus: TodoStatus
+)

--- a/data/src/main/java/com/takseha/data/source/local/entity/mystudy/applicant/StudyApplicantEntity.kt
+++ b/data/src/main/java/com/takseha/data/source/local/entity/mystudy/applicant/StudyApplicantEntity.kt
@@ -1,0 +1,21 @@
+package com.takseha.data.source.local.entity.mystudy.applicant
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "StudyApplicant")
+class StudyApplicantEntity(
+    @PrimaryKey val id: Int,
+    @ColumnInfo("studyId") val studyId: Int,
+    @ColumnInfo("name") val name: String,
+    @ColumnInfo("githubId") val githubId: String,
+    @ColumnInfo("profileUrl") val profileUrl: String,
+    @ColumnInfo("profilePublicYn") val profilePublicYn: Boolean,
+    @ColumnInfo("signGreeting") val signGreeting: String,
+    @ColumnInfo("appliedAt") val appliedAt: String,
+    @ColumnInfo("githubLink") val githubLink: String?,
+    @ColumnInfo("blogLink") val blogLink: String?,
+    @ColumnInfo("linkedInLink") val linkedInLink: String?,
+)
+

--- a/data/src/main/java/com/takseha/data/source/local/entity/notification/NotificationEntity.kt
+++ b/data/src/main/java/com/takseha/data/source/local/entity/notification/NotificationEntity.kt
@@ -1,0 +1,14 @@
+package com.takseha.data.source.local.entity.notification
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "Notification")
+class NotificationEntity(
+    @PrimaryKey val id: String,
+    @ColumnInfo("studyId") val studyId: Int,
+    @ColumnInfo("createdAt") val createdAt: String,
+    @ColumnInfo("title") val title: String,
+    @ColumnInfo("message") val message: String
+)

--- a/data/src/main/java/com/takseha/data/source/local/entity/study/StudyRankEntity.kt
+++ b/data/src/main/java/com/takseha/data/source/local/entity/study/StudyRankEntity.kt
@@ -1,0 +1,12 @@
+package com.takseha.data.source.local.entity.study
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "StudyRank")
+class StudyRankEntity(
+    @PrimaryKey val studyId: Int,
+    @ColumnInfo("rank") val rank: Int,
+    @ColumnInfo("score") val score: Int
+)


### PR DESCRIPTION
## ☝️연관된 이슈

<b>#61</b>

## ✌️구현 내용
> 📌 요약: 마이스터디 목록/홈 화면 관련 entity 정의

- `GetMyStudiesUseCase`
: 마이스터디 메뉴 화면 정보 조회

- `MyStudySummaryEntity`
: 마이스터디 목록 아이템 내 스터디 정보 

- `TodoSummaryEntity`
: 마이스터디 목록 아이템 내 마감일 임박 투두 정보

- `MyStudyDetailEntity`
: 마이스터디 홈 화면 내 상세 정보

- `MyStudyCategoryEntity`
: 마이스터디 카테고리 정보

- `MyStudyMemberEntity`
: 마이스터디 멤버 정보

- `MyStudyCommentEntity`
: 마이스터디 게시글 정보
