### PR TITLE
Feat(#65): [data] mapper 구현 - 마이스터디 홈 화면 관련

### DIFF
--- a/data/src/main/java/com/takseha/data/mapper/mystudy/MyStudyCategoriesMapper.kt
+++ b/data/src/main/java/com/takseha/data/mapper/mystudy/MyStudyCategoriesMapper.kt
@@ -1,0 +1,30 @@
+package com.takseha.data.mapper.mystudy
+
+import com.takseha.data.source.local.entity.mystudy.MyStudyCategoryEntity
+import com.takseha.data.source.remote.dto.study.response.StudyDetailResponse
+import com.takseha.domain.model.mystudy.MyStudyDetail
+
+object MyStudyCategoriesMapper {
+    /** dto -> entity */
+    fun toEntity(dto: StudyDetailResponse): List<MyStudyCategoryEntity> =
+        dto.categoryNames.map { categoryName ->
+            MyStudyCategoryEntity(
+                studyId = dto.id,
+                category = categoryName
+            )
+        }
+
+    /** model -> entity */
+    fun toEntity(model: MyStudyDetail): List<MyStudyCategoryEntity> =
+        model.studyCategoryList.map { categoryName ->
+            MyStudyCategoryEntity(
+                studyId = model.id,
+                category = categoryName
+            )
+        }
+
+    /** entity -> model */
+    fun toDomain(entity: List<MyStudyCategoryEntity>): List<String> = entity.map {
+        it.category
+    }
+}

--- a/data/src/main/java/com/takseha/data/mapper/mystudy/MyStudyCommentsMapper.kt
+++ b/data/src/main/java/com/takseha/data/mapper/mystudy/MyStudyCommentsMapper.kt
@@ -1,0 +1,48 @@
+package com.takseha.data.mapper.mystudy
+
+import com.takseha.data.source.local.entity.mystudy.MyStudyCommentEntity
+import com.takseha.data.source.remote.dto.mystudy.response.CommentResponse
+import com.takseha.domain.model.mystudy.MyStudyComment
+
+object MyStudyCommentsMapper {
+    /** dto -> entity */
+    fun toEntity(dto: List<CommentResponse>): List<MyStudyCommentEntity> =
+        dto.map {
+            MyStudyCommentEntity(
+                id = it.id,
+                studyId = it.studyInfoId,
+                writerName = it.userInfo.name,
+                writerProfileUrl = it.userInfo.profileImageUrl,
+                content = it.content,
+                createdAt = it.commentSetDate,
+                isMyComment = it.isMyComment
+            )
+        }
+
+    /** model -> entity */
+    fun toEntity(model: List<MyStudyComment>): List<MyStudyCommentEntity> =
+        model.map {
+            MyStudyCommentEntity(
+                id = it.id,
+                studyId = it.studyId,
+                writerName = it.writerName,
+                writerProfileUrl = it.writerProfileUrl,
+                content = it.content,
+                createdAt = it.createdAt,
+                isMyComment = it.isMyComment
+            )
+        }
+
+    /** entity -> model */
+    fun toDomain(entity: List<MyStudyCommentEntity>): List<MyStudyComment> = entity.map {
+        MyStudyComment(
+            id = it.id,
+            studyId = it.studyId,
+            writerName = it.writerName,
+            writerProfileUrl = it.writerProfileUrl,
+            content = it.content,
+            createdAt = it.createdAt,
+            isMyComment = it.isMyComment
+        )
+    }
+}

--- a/data/src/main/java/com/takseha/data/mapper/mystudy/MyStudyDetailMapper.kt
+++ b/data/src/main/java/com/takseha/data/mapper/mystudy/MyStudyDetailMapper.kt
@@ -1,0 +1,54 @@
+package com.takseha.data.mapper.mystudy
+
+import com.takseha.data.source.local.entity.mystudy.MyStudyCategoryEntity
+import com.takseha.data.source.local.entity.mystudy.MyStudyDetailEntity
+import com.takseha.data.source.local.entity.mystudy.applicant.StudyApplicantEntity
+import com.takseha.data.source.remote.dto.mystudy.response.StudyApplicantResponse
+import com.takseha.data.source.remote.dto.study.response.StudyDetailResponse
+import com.takseha.domain.model.mystudy.MyStudyDetail
+import com.takseha.domain.model.mystudy.applicant.StudyApplicant
+import com.takseha.domain.model.profile.SocialInfo
+import com.takseha.domain.model.study.StudyCycle
+import com.takseha.domain.model.study.StudyStatus
+
+object MyStudyDetailMapper {
+    /** dto -> entity */
+    // TODO: githubRepoUrl 로직 추후 수정
+    fun toEntity(dto: StudyDetailResponse): MyStudyDetailEntity =
+        MyStudyDetailEntity(
+            id = dto.id,
+            studyName = dto.topic,
+            info = dto.info,
+            cycle = dto.periodType.toString(),
+            status = dto.status.toString(),
+            studyProfileUrl = dto.profileImageUrl,
+            isLeader = dto.isLeader,
+            githubRepoUrl = dto.githubLinkInfo.branchName
+        )
+
+    /** model -> entity */
+    fun toEntity(model: MyStudyDetail): MyStudyDetailEntity =
+        MyStudyDetailEntity(
+            id = model.id,
+            studyName = model.studyName,
+            info = model.info,
+            cycle = model.cycle.toString(),
+            status = model.status.toString(),
+            studyProfileUrl = model.studyProfileUrl,
+            isLeader = model.isLeader,
+            githubRepoUrl = model.githubRepoUrl
+        )
+
+    /** entity -> model */
+    fun toDomain(myStudyDetailEntity: MyStudyDetailEntity, myStudyCategoryEntities: List<MyStudyCategoryEntity>): MyStudyDetail = MyStudyDetail(
+        id = myStudyDetailEntity.id,
+        studyName = myStudyDetailEntity.studyName,
+        info = myStudyDetailEntity.info,
+        cycle = StudyCycle.from(myStudyDetailEntity.cycle),
+        status = StudyStatus.from(myStudyDetailEntity.status),
+        studyProfileUrl = myStudyDetailEntity.studyProfileUrl,
+        isLeader = myStudyDetailEntity.isLeader,
+        githubRepoUrl = myStudyDetailEntity.githubRepoUrl,
+        studyCategoryList = myStudyCategoryEntities.map { it.category }
+    )
+}

--- a/data/src/main/java/com/takseha/data/mapper/mystudy/StudyApplicantsMapper.kt
+++ b/data/src/main/java/com/takseha/data/mapper/mystudy/StudyApplicantsMapper.kt
@@ -1,0 +1,60 @@
+package com.takseha.data.mapper.mystudy
+
+import com.takseha.data.source.local.entity.mystudy.applicant.StudyApplicantEntity
+import com.takseha.data.source.remote.dto.mystudy.response.StudyApplicantResponse
+import com.takseha.domain.model.mystudy.applicant.StudyApplicant
+import com.takseha.domain.model.profile.SocialInfo
+
+object StudyApplicantsMapper {
+    /** dto -> entity */
+    fun toEntity(studyId: Int, dto: List<StudyApplicantResponse>): List<StudyApplicantEntity> =
+        dto.map {
+            StudyApplicantEntity(
+                id = it.id,
+                studyId = studyId,
+                name = it.name,
+                githubId = it.githubId,
+                profileUrl = it.profileImageUrl,
+                profilePublicYn = it.profilePublicYn,
+                signGreeting = it.joinReason,
+                appliedAt = it.createdDateTime,
+                githubLink = it.socialInfo?.githubLink,
+                blogLink = it.socialInfo?.blogLink,
+                linkedInLink = it.socialInfo?.linkedInLink
+            )
+        }
+
+    /** model -> entity */
+    fun toEntity(studyId: Int, model: List<StudyApplicant>): List<StudyApplicantEntity> =
+        model.map {
+            StudyApplicantEntity(
+                id = it.id,
+                studyId = studyId,
+                name = it.name,
+                githubId = it.githubId,
+                profileUrl = it.profileUrl,
+                profilePublicYn = it.profilePublicYn,
+                signGreeting = it.signGreeting,
+                appliedAt = it.appliedAt,
+                githubLink = it.socialInfo?.githubLink,
+                blogLink = it.socialInfo?.blogLink,
+                linkedInLink = it.socialInfo?.linkedInLink
+            )
+        }
+
+    /** entity -> model */
+    fun toDomain(entity: StudyApplicantEntity): StudyApplicant = StudyApplicant(
+        id = entity.id,
+        name = entity.name,
+        githubId = entity.githubId,
+        profileUrl = entity.profileUrl,
+        profilePublicYn = entity.profilePublicYn,
+        signGreeting = entity.signGreeting,
+        appliedAt = entity.appliedAt,
+        socialInfo = SocialInfo(
+            githubLink = entity.githubLink,
+            blogLink = entity.blogLink,
+            linkedInLink = entity.linkedInLink
+        )
+    )
+}

--- a/data/src/main/java/com/takseha/data/mapper/mystudy/StudyRankMapper.kt
+++ b/data/src/main/java/com/takseha/data/mapper/mystudy/StudyRankMapper.kt
@@ -1,0 +1,29 @@
+package com.takseha.data.mapper.mystudy
+
+import com.takseha.data.source.local.entity.study.StudyRankEntity
+import com.takseha.data.source.remote.dto.study.response.StudyRankResponse
+import com.takseha.domain.model.study.StudyRank
+
+object StudyRankMapper {
+    /** dto -> entity */
+    fun toEntity(studyId: Int, dto: StudyRankResponse): StudyRankEntity =
+        StudyRankEntity(
+            studyId = studyId,
+            rank = dto.rank,
+            score = dto.score
+        )
+
+    /** model -> entity */
+    fun toEntity(studyId: Int, model: StudyRank): StudyRankEntity =
+        StudyRankEntity(
+            studyId = studyId,
+            rank = model.rank,
+            score = model.score
+        )
+
+    /** entity -> model */
+    fun toDomain(entity: StudyRankEntity): StudyRank = StudyRank(
+        rank = entity.rank,
+        score = entity.score
+    )
+}

--- a/data/src/main/java/com/takseha/data/mapper/mystudy/TodoSummaryMapper.kt
+++ b/data/src/main/java/com/takseha/data/mapper/mystudy/TodoSummaryMapper.kt
@@ -1,0 +1,43 @@
+package com.takseha.data.mapper.mystudy
+
+import com.takseha.data.source.local.entity.mystudy.TodoSummaryEntity
+import com.takseha.data.source.remote.dto.todo.response.TodoSummaryResponse
+import com.takseha.domain.model.mystudy.TodoStatus
+import com.takseha.domain.model.mystudy.TodoSummary
+
+object TodoSummaryMapper {
+    /** dto -> entity */
+    fun toEntity(dto: TodoSummaryResponse): TodoSummaryEntity =
+        TodoSummaryEntity(
+            id = dto.todo!!.id,
+            studyId = dto.todo.studyInfoId,
+            title = dto.todo.title,
+            deadline = dto.todo.todoDate,
+            completeMemberCount = dto.completeMemberCount,
+            totalMemberCount = dto.totalMemberCount,
+            myStatus = dto.myStatus.toString()
+        )
+
+    /** model -> entity */
+    fun toEntity(model: TodoSummary):  TodoSummaryEntity =
+        TodoSummaryEntity(
+            id = model.id,
+            studyId = model.studyId,
+            title = model.title,
+            deadline = model.deadline,
+            completeMemberCount = model.completeMemberCount,
+            totalMemberCount = model.totalMemberCount,
+            myStatus = model.myStatus.toString()
+        )
+
+    /** entity -> model */
+    fun toDomain(entity: TodoSummaryEntity): TodoSummary = TodoSummary(
+        id = entity.id,
+        studyId = entity.studyId,
+        title = entity.title,
+        deadline = entity.deadline,
+        completeMemberCount = entity.completeMemberCount,
+        totalMemberCount = entity.totalMemberCount,
+        myStatus = TodoStatus.from(entity.myStatus)
+    )
+}

--- a/data/src/main/java/com/takseha/data/source/local/entity/mystudy/TodoSummaryEntity.kt
+++ b/data/src/main/java/com/takseha/data/source/local/entity/mystudy/TodoSummaryEntity.kt
@@ -13,5 +13,5 @@ class TodoSummaryEntity(
     @ColumnInfo("deadline") val deadline: String,
     @ColumnInfo("completeMemberCount") val completeMemberCount: Int,
     @ColumnInfo("totalMemberCount") val totalMemberCount: Int,
-    @ColumnInfo("myStatus") val myStatus: TodoStatus
+    @ColumnInfo("myStatus") val myStatus: String
 )

--- a/domain/src/main/java/com/takseha/domain/model/mystudy/TodoStatus.kt
+++ b/domain/src/main/java/com/takseha/domain/model/mystudy/TodoStatus.kt
@@ -1,5 +1,11 @@
 package com.takseha.domain.model.mystudy
 
 enum class TodoStatus {
-    TODO_INCOMPLETE, TODO_COMPLETE, TODO_OVERDUE
+    TODO_INCOMPLETE, TODO_COMPLETE, TODO_OVERDUE;
+
+    companion object {
+        fun from(value: String): TodoStatus =
+            TodoStatus.entries.find { it.name.equals(value, ignoreCase = true) }
+                ?: TODO_INCOMPLETE // 기본값
+    }
 }

--- a/domain/src/main/java/com/takseha/domain/model/study/StudyCycle.kt
+++ b/domain/src/main/java/com/takseha/domain/model/study/StudyCycle.kt
@@ -1,5 +1,11 @@
 package com.takseha.domain.model.study
 
 enum class StudyCycle {
-    STUDY_PERIOD_EVERYDAY, STUDY_PERIOD_WEEK, STUDY_PERIOD_NONE
+    STUDY_PERIOD_EVERYDAY, STUDY_PERIOD_WEEK, STUDY_PERIOD_NONE;
+
+    companion object {
+        fun from(value: String): StudyCycle =
+            entries.find { it.name.equals(value, ignoreCase = true) }
+                ?: STUDY_PERIOD_WEEK // 기본값
+    }
 }

--- a/domain/src/main/java/com/takseha/domain/model/study/StudyStatus.kt
+++ b/domain/src/main/java/com/takseha/domain/model/study/StudyStatus.kt
@@ -1,5 +1,11 @@
 package com.takseha.domain.model.study
 
 enum class StudyStatus {
-    STUDY_PUBLIC, STUDY_PRIVATE, STUDY_DELETED, STUDY_INACTIVE
+    STUDY_PUBLIC, STUDY_PRIVATE, STUDY_DELETED, STUDY_INACTIVE;
+
+    companion object {
+        fun from(value: String): StudyStatus =
+            StudyStatus.entries.find { it.name.equals(value, ignoreCase = true) }
+                ?: STUDY_PUBLIC // 기본값
+    }
 }


### PR DESCRIPTION
## ☝️연관된 이슈

<b>#65</b>

## ✌️구현 내용
> 📌 요약: 마이스터디 목록/홈 화면 관련 mapper 구현
- `MyStudyCategoriesMapper`
: 마이스터디 카테고리 mapper

- `MyStudyCommentsMapper`
: 마이스터디 게시글 mapper

- `MyStudyDetailMapper`
: 마이스터디 상세 정보 mapper

- `StudyRankMapper`
: 마이스터디 랭킹 정보 mapper

- `TodoSummaryMapper`
: 마감일 임박 투두 정보 mapper

