### PR TITLE
Feat(#67): [data] safeApiCall() 및 ExceptionToFailureMapper 구현

### DIFF
--- a/data/src/main/java/com/takseha/data/mapper/exception/ExceptionToFailureMapper.kt
+++ b/data/src/main/java/com/takseha/data/mapper/exception/ExceptionToFailureMapper.kt
@@ -1,0 +1,40 @@
+package com.takseha.data.mapper.exception
+
+import android.database.sqlite.SQLiteConstraintException
+import android.database.sqlite.SQLiteException
+import com.google.gson.JsonParseException
+import com.google.gson.JsonSyntaxException
+import com.takseha.domain.model.common.Failure
+import retrofit2.HttpException
+import java.net.ConnectException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+import java.util.concurrent.TimeoutException
+
+class ExceptionToFailureMapper {
+    companion object {
+        fun map(e: Exception): Failure {
+            return when (e) {
+                /** 서버 관련 오류 */
+                is ConnectException, is SocketTimeoutException, is HttpException -> {
+                    Failure.ServerFailure(e)
+                }
+
+                /** 인터넷 연결 실패 */
+                is TimeoutException, is UnknownHostException -> {
+                    Failure.NetworkFailure(e)
+                }
+
+                /** db 오류 */
+                is JsonSyntaxException, is JsonParseException, is SQLiteConstraintException, is SQLiteException -> {
+                    Failure.DatabaseFailure(e)
+                }
+
+                /** 기타 Data Layer 오류 */
+                else -> {
+                    Failure.UnexpectedDataFailure(e)
+                }
+            }
+        }
+    }
+}

--- a/data/src/main/java/com/takseha/data/utils/safeApiCall.kt
+++ b/data/src/main/java/com/takseha/data/utils/safeApiCall.kt
@@ -1,0 +1,38 @@
+package com.takseha.data.utils
+
+import com.takseha.data.mapper.exception.ExceptionToFailureMapper
+import com.takseha.domain.model.common.Failure
+import retrofit2.Response
+
+suspend fun <T, R> safeApiCall(
+    call: suspend () -> Response<T>,
+    mapper: (T) -> R,
+    successApi: (suspend (T) -> Unit)? = null
+): R {
+    return try {
+        val response = call.invoke()
+        val body = response.body()
+
+        when {
+            !response.isSuccessful -> {   // response.code != 200
+                val statusCode = response.code()
+                val errorDesc = "HTTP Error($statusCode)"
+
+                throw Failure.ServerFailure(Exception(errorDesc))
+            }
+
+            body == null -> {   // null 반환
+                throw Failure.ServerFailure(Exception("null 반환"))
+            }
+
+            else -> {
+                successApi?.let { apiCall ->
+                    apiCall(body)
+                }
+                mapper(body)
+            }
+        }
+    } catch (e: Exception) {
+        throw ExceptionToFailureMapper.map(e)   // 에러 발생 시 자동으로 Failure로 래핑해서 throw
+    }
+}

--- a/presentation/src/main/java/com/takseha/presentation/exception/ExceptionToFailureMapper.kt
+++ b/presentation/src/main/java/com/takseha/presentation/exception/ExceptionToFailureMapper.kt
@@ -1,0 +1,28 @@
+package com.takseha.presentation.exception
+
+import com.takseha.domain.model.common.Failure
+import java.io.IOException
+import java.nio.BufferOverflowException
+
+class ExceptionToFailureMapper {
+    companion object {
+        fun map(e: Exception): Failure {
+            return when (e) {
+                /** App Crash 발생 */
+                is IllegalStateException, is NullPointerException, is IllegalArgumentException, is OutOfMemoryError -> {
+                    Failure.AppCrashFailure(e)
+                }
+
+                /** 데이터 접근 실패 */
+                is IndexOutOfBoundsException, is BufferOverflowException, is IOException -> {
+                    Failure.UiFailure(e)
+                }
+
+                /** 기타 Presentation layer 오류 */
+                else -> {
+                    Failure.UnexpectedUiFailure(e)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## ☝️연관된 이슈

<b>#67</b>

## ✌️구현 내용
> 📌 요약: `safeApiCall()` 및 `ExceptionToFailureMapper` 구현

모든 api 호출 시 공통으로 사용할 수 있는 safeApiCall() 유틸 메소드를 구현한다. 
safeApiCall()에서 발생하는 모든 에러를 Failure로 래핑해서 throw하기 위해 ExceptionToFailureMapper를 구현한다.
