### PR TITLE
Feat(#77): [data] repositoryImpl 구현 - 마이스터디 목록/홈 화면 관련

### DIFF
--- a/core/src/main/java/com/takseha/core/di/RepositoryModule.kt
+++ b/core/src/main/java/com/takseha/core/di/RepositoryModule.kt
@@ -1,5 +1,6 @@
 package com.takseha.core.di
 
+import com.takseha.data.repositoryimpl.MyStudyRepositoryImpl
 import com.takseha.domain.repository.AuthRepository
 import com.takseha.domain.repository.CommitRepository
 import com.takseha.domain.repository.MyStudyRepository
@@ -22,8 +23,11 @@ abstract class RepositoryModule {
 //    @Binds
 //    abstract fun CommitRepository(repositoryImpl: CommitRepositoryImpl): CommitRepository
 //
+    @Binds
+    abstract fun MyStudyRepository(repositoryImpl: MyStudyRepositoryImpl): MyStudyRepository
+//
 //    @Binds
-//    abstract fun MyStudyRepository(repositoryImpl: MyStudyRepositoryImpl): MyStudyRepository
+//    abstract fun MyStudySettingRepository(repository: MyStudySettingRepositoryImpl): MyStudySettingRepository
 //
 //    @Binds
 //    abstract fun NotificationRepository(repository: NotificationRepositoryImpl): NotificationRepository

--- a/data/src/main/java/com/takseha/data/repositoryimpl/MyStudyRepositoryImpl.kt
+++ b/data/src/main/java/com/takseha/data/repositoryimpl/MyStudyRepositoryImpl.kt
@@ -1,0 +1,150 @@
+package com.takseha.data.repositoryimpl
+
+import com.takseha.data.mapper.exception.ExceptionToFailureMapper
+import com.takseha.data.mapper.mystudy.MyStudySummariesMapper
+import com.takseha.data.mapper.mystudy.TodoSummaryMapper
+import com.takseha.data.source.local.GitudyDatabase
+import com.takseha.data.source.remote.api.StudyService
+import com.takseha.data.source.remote.dto.study.response.StudiesResponse
+import com.takseha.data.source.remote.dto.todo.response.TodoSummaryResponse
+import com.takseha.data.utils.safeApiCall
+import com.takseha.domain.model.mystudy.MyStudyComment
+import com.takseha.domain.model.mystudy.MyStudyDetail
+import com.takseha.domain.model.mystudy.MyStudyMember
+import com.takseha.domain.model.mystudy.MyStudySummary
+import com.takseha.domain.model.mystudy.TodoSummary
+import com.takseha.domain.model.study.StudyRank
+import com.takseha.domain.repository.MyStudyRepository
+import javax.inject.Inject
+
+class MyStudyRepositoryImpl @Inject constructor(
+    private val myStudyService: StudyService,
+    private val gitudyDatabase: GitudyDatabase
+) : MyStudyRepository {
+    override suspend fun getMyStudySummaries(
+        cursorIdx: Long?,
+        limit: Long,
+        sortBy: String
+    ): List<MyStudySummary>? {
+        return try {
+            val myStudySummaryEntities = gitudyDatabase.dao().getMyStudySummaries(
+                cursorIdx = cursorIdx,
+                limit = limit,
+                sortBy = sortBy
+            )
+
+            MyStudySummariesMapper.toModels(myStudySummaryEntities)
+        } catch (e: Exception) {
+            throw ExceptionToFailureMapper.map(e)
+        }
+    }
+
+    override suspend fun fetchMyStudySummaries(
+        cursorIdx: Long?,
+        limit: Long,
+        sortBy: String
+    ): List<MyStudySummary> {
+        return safeApiCall(
+            call = { myStudyService.fetchStudies(cursorIdx = cursorIdx, limit = limit, sortBy = sortBy, myStudy = true) },
+            mapper = { MyStudySummariesMapper.toModels(it) },
+            successApi = { saveMyStudySummaries(it) }
+        )
+    }
+
+    override suspend fun getNearestDeadlineTodoInfo(studyId: Int): TodoSummary? {
+        return try {
+            val todoSummaryEntity = gitudyDatabase.dao().getNearestDeadlineTodoInfo(studyId)
+
+            TodoSummaryMapper.toModel(todoSummaryEntity)
+        } catch (e: Exception) {
+            throw ExceptionToFailureMapper.map(e)
+        }
+    }
+
+    override suspend fun fetchNearestDeadlineTodoInfo(studyId: Int): TodoSummary? {
+        return safeApiCall(
+            call = { myStudyService.fetchNearestDeadlineTodo(studyId) },
+            mapper = { TodoSummaryMapper.toModel(it) },
+            successApi = { saveNearestDeadlineTodo(it) }
+        )
+    }
+
+    override suspend fun getMyStudyCount(): Int? {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun fetchMyStudyCount(): Int {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun fetchStudyRankAndScore(studyId: Int): StudyRank {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun getMyStudyDetail(studyId: Int): MyStudyDetail? {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun fetchMyStudyDetail(studyId: Int): MyStudyDetail {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun fetchMyStudyMembers(studyId: Int): List<MyStudyMember> {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun getMyStudyComments(
+        cursorIdx: Long?,
+        limit: Long,
+        studyId: Int
+    ): List<MyStudyComment>? {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun fetchMyStudyComments(
+        cursorIdx: Long?,
+        limit: Long,
+        studyId: Int
+    ): List<MyStudyComment> {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun postMyStudyComment(studyId: Int, comment: String) {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun updateMyStudyComment(studyId: Int, studyCommentId: Int, comment: String) {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun deleteMyStudyComment(studyId: Int, studyCommentId: Int) {
+        TODO("Not yet implemented")
+    }
+
+
+    private suspend fun saveMyStudySummaries(myStudySummaries: StudiesResponse) {
+        try {
+            val myStudySummaryEntities = MyStudySummariesMapper.toEntities(myStudySummaries)
+            gitudyDatabase.dao().apply {
+                deleteMyStudySummaries()
+                insertMyStudySummaries(myStudySummaryEntities)
+            }
+        } catch (e: Exception) {
+            throw ExceptionToFailureMapper.map(e)
+        }
+    }
+
+    private suspend fun saveNearestDeadlineTodo(nearestDeadlineTodo: TodoSummaryResponse) {
+        if (nearestDeadlineTodo.todo == null) return
+
+        try {
+            val todoSummaryEntity = TodoSummaryMapper.toEntity(nearestDeadlineTodo)
+            gitudyDatabase.dao().apply {
+                deleteNearestDeadlineTodoInfos(nearestDeadlineTodo.todo.id)
+                insertNearestDeadlineTodoInfo(todoSummaryEntity)
+            }
+        } catch (e: Exception) {
+            throw ExceptionToFailureMapper.map(e)
+        }
+    }
+}

--- a/data/src/main/java/com/takseha/data/utils/safeApiCall.kt
+++ b/data/src/main/java/com/takseha/data/utils/safeApiCall.kt
@@ -1,7 +1,7 @@
 package com.takseha.data.utils
 
 import com.takseha.data.mapper.exception.ExceptionToFailureMapper
-import com.takseha.domain.model.common.Failure
+import com.takseha.domain.model.common.ServerFailure
 import retrofit2.Response
 
 suspend fun <T, R> safeApiCall(
@@ -18,11 +18,11 @@ suspend fun <T, R> safeApiCall(
                 val statusCode = response.code()
                 val errorDesc = "HTTP Error($statusCode)"
 
-                throw Failure.ServerFailure(Exception(errorDesc))
+                throw ServerFailure(Exception(errorDesc))
             }
 
             body == null -> {   // null 반환
-                throw Failure.ServerFailure(Exception("null 반환"))
+                throw ServerFailure(Exception("null 반환"))
             }
 
             else -> {

--- a/domain/src/main/java/com/takseha/domain/repository/MyStudyRepository.kt
+++ b/domain/src/main/java/com/takseha/domain/repository/MyStudyRepository.kt
@@ -5,7 +5,6 @@ import com.takseha.domain.model.mystudy.MyStudyDetail
 import com.takseha.domain.model.mystudy.MyStudyMember
 import com.takseha.domain.model.mystudy.MyStudySummary
 import com.takseha.domain.model.mystudy.TodoSummary
-import com.takseha.domain.model.mystudy.applicant.StudyApplicant
 import com.takseha.domain.model.study.StudyRank
 
 interface MyStudyRepository {
@@ -38,20 +37,4 @@ interface MyStudyRepository {
     suspend fun updateMyStudyComment(studyId: Int, studyCommentId: Int, comment: String)
     /** 커뮤니티 글 삭제 */
     suspend fun deleteMyStudyComment(studyId: Int, studyCommentId: Int)
-
-    /** 스터디 신청자 목록 확인 */
-    suspend fun getStudyApplications(cursorIdx: Long?, limit: Long, studyId: Int): List<StudyApplicant>?
-    suspend fun fetchStudyApplications(cursorIdx: Long?, limit: Long, studyId: Int): List<StudyApplicant>
-
-    /** 스터디 신청 승인/거절 */
-    suspend fun respondToStudyApplication(studyId: Int, applicantId: Int, isAccepted: Boolean)
-
-    /** 스터디 탈퇴 */
-    suspend fun withdrawFromStudy(studyId: Int)
-
-    /** 스터디 종료 */
-    suspend fun endStudy(studyId: Int)
-
-    /** 스터디 삭제 */
-    suspend fun deleteStudy(studyId: Int)
 }

--- a/domain/src/main/java/com/takseha/domain/repository/MyStudySettingRepository.kt
+++ b/domain/src/main/java/com/takseha/domain/repository/MyStudySettingRepository.kt
@@ -1,0 +1,21 @@
+package com.takseha.domain.repository
+
+import com.takseha.domain.model.mystudy.applicant.StudyApplicant
+
+interface MyStudySettingRepository {
+    /** 스터디 신청자 목록 확인 */
+    suspend fun getStudyApplications(cursorIdx: Long?, limit: Long, studyId: Int): List<StudyApplicant>?
+    suspend fun fetchStudyApplications(cursorIdx: Long?, limit: Long, studyId: Int): List<StudyApplicant>
+
+    /** 스터디 신청 승인/거절 */
+    suspend fun respondToStudyApplication(studyId: Int, applicantId: Int, isAccepted: Boolean)
+
+    /** 스터디 탈퇴 */
+    suspend fun withdrawFromStudy(studyId: Int)
+
+    /** 스터디 종료 */
+    suspend fun endStudy(studyId: Int)
+
+    /** 스터디 삭제 */
+    suspend fun deleteStudy(studyId: Int)
+}


### PR DESCRIPTION
## ☝️연관된 이슈

<b>#77</b>

## ✌️구현 내용
> 📌 요약: MyStudyRepository 관련 repositoryImpl 구현

- `MyStudyRepository` 분리
- `MyStudyRepositoryImpl` 구현
: 마이스터디 홈 관련 메소드 구현
- `RepositoryModule`에 관련 의존성 추가
