### PR TITLE
Feat(#81): [presentation] 마이스터디 상세 화면 View 및 ViewModel 구현

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,10 +30,13 @@ firebaseBom = "33.13.0"
 googleServices = "4.4.2"
 googleCrashlytics = "3.0.3"
 
+swiperefreshlayout = "1.1.0"
+
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-navigation-fragment-ktx = { module = "androidx.navigation:navigation-fragment-ktx", version.ref = "navigationFragmentKtx" }
 androidx-navigation-ui-ktx = { module = "androidx.navigation:navigation-ui-ktx", version.ref = "navigationFragmentKtx" }
+androidx-swiperefreshlayout = { module = "androidx.swiperefreshlayout:swiperefreshlayout", version.ref = "swiperefreshlayout" }
 glide = { module = "com.github.bumptech.glide:glide", version.ref = "glide" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -32,6 +32,12 @@ android {
     kotlinOptions {
         jvmTarget = "11"
     }
+    dataBinding {
+        enable = true
+    }
+    viewBinding {
+        enable = true
+    }
 }
 
 dependencies {
@@ -60,4 +66,7 @@ dependencies {
     // coroutines
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.coroutines.android)
+
+    // swipeRefreshLayout
+    implementation(libs.androidx.swiperefreshlayout)
 }

--- a/presentation/src/main/java/com/takseha/presentation/view/base/UiState.kt
+++ b/presentation/src/main/java/com/takseha/presentation/view/base/UiState.kt
@@ -1,0 +1,10 @@
+package com.takseha.presentation.view.base
+
+import com.takseha.domain.model.common.Failure
+
+sealed class UiState<out T>
+
+data object Init : UiState<Nothing>()
+data object Loading : UiState<Nothing>()
+data class Success<out T>(val data: T) : UiState<T>()
+data class Error(val message: String, val failure: Failure? = null) : UiState<Nothing>()

--- a/presentation/src/main/java/com/takseha/presentation/view/mystudy/MyStudyFragment.kt
+++ b/presentation/src/main/java/com/takseha/presentation/view/mystudy/MyStudyFragment.kt
@@ -1,0 +1,100 @@
+package com.takseha.presentation.view.mystudy
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import com.takseha.domain.model.common.Failure
+import com.takseha.presentation.databinding.FragmentMyStudyBinding
+import com.takseha.presentation.view.base.Error
+import com.takseha.presentation.view.base.Init
+import com.takseha.presentation.view.base.Loading
+import com.takseha.presentation.view.base.Success
+import com.takseha.presentation.view.base.UiState
+import com.takseha.presentation.viewmodel.MyStudyBasicUiModel
+import com.takseha.presentation.viewmodel.MyStudyViewModel
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+
+/**
+ * 마이스터디 상세 화면 (메인)
+ */
+//TODO: BaseFragment 구현 후 상속 받기
+class MyStudyFragment : Fragment() {
+    private var _binding: FragmentMyStudyBinding? = null
+    private val binding get() = _binding!!
+
+    private val viewModel: MyStudyViewModel by viewModels()
+
+    private var studyId: Int? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        arguments?.let {
+            //TODO: argument key 따로 정의
+            studyId = it.getInt("studyId")
+        }
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentMyStudyBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        initListeners()
+        observeUiState()
+    }
+
+    /** UI 이벤트 관련 초기화 */
+    private fun initListeners() {
+        //TODO: UI 이벤트 리스너 초기화 필요
+    }
+
+    /** UiState Observe */
+    private fun observeUiState() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.myStudyBasicState.collectLatest { handleUiState(it) }
+            }
+        }
+    }
+
+    /** UiState 상태에 따른 화면 구현 */
+    private fun handleUiState(uiState: UiState<MyStudyBasicUiModel>) {
+        when (uiState) {
+            is Error -> showError(uiState.message, uiState.failure)
+            Init -> showInitView()
+            Loading -> showLoading()
+            is Success -> showContent(uiState.data)
+        }
+    }
+
+    //TODO: BaseFragment 공통으로 정의
+    /** 초기 화면 구현 */
+    private fun showInitView() {
+    }
+    /** 로딩 화면 구현 */
+    private fun showLoading() {
+    }
+    /** 정상 UI 구현 */
+    private fun showContent(data: MyStudyBasicUiModel) {
+    }
+    /** 에러 발생 시 UI 구현 */
+    private fun showError(alertMessage: String, failure: Failure? = null) {
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/presentation/src/main/java/com/takseha/presentation/viewmodel/MyStudyViewModel.kt
+++ b/presentation/src/main/java/com/takseha/presentation/viewmodel/MyStudyViewModel.kt
@@ -1,0 +1,118 @@
+package com.takseha.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.takseha.domain.model.common.AppCrashFailure
+import com.takseha.domain.model.common.BusinessFailure
+import com.takseha.domain.model.common.DatabaseFailure
+import com.takseha.domain.model.common.Failure
+import com.takseha.domain.model.common.NetworkFailure
+import com.takseha.domain.model.common.ServerFailure
+import com.takseha.domain.model.common.UiFailure
+import com.takseha.domain.model.common.UnexpectedDataFailure
+import com.takseha.domain.model.common.UnexpectedUiFailure
+import com.takseha.domain.model.common.ValidationFailure
+import com.takseha.domain.model.mystudy.MyStudyComment
+import com.takseha.domain.model.mystudy.MyStudyDetail
+import com.takseha.domain.model.mystudy.MyStudyMember
+import com.takseha.domain.model.mystudy.TodoSummary
+import com.takseha.domain.usecase.mystudy.GetMyStudyCommentsUseCase
+import com.takseha.domain.usecase.mystudy.GetMyStudyDetailUseCase
+import com.takseha.domain.usecase.mystudy.GetMyStudyMembersUseCase
+import com.takseha.domain.usecase.mystudy.GetMyStudyRankAndScoreUseCase
+import com.takseha.domain.usecase.mystudy.GetNearestDeadlineTodoUseCase
+import com.takseha.domain.usecase.mystudy.PostMyStudyCommentUseCase
+import com.takseha.presentation.view.base.Error
+import com.takseha.presentation.view.base.Init
+import com.takseha.presentation.view.base.Loading
+import com.takseha.presentation.view.base.Success
+import com.takseha.presentation.view.base.UiState
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+class MyStudyViewModel @Inject constructor(
+    private val getMyStudyDetailUseCase: GetMyStudyDetailUseCase,
+    private val getMyStudyRankAndScoreUseCase: GetMyStudyRankAndScoreUseCase,
+    private val getNearestDeadlineTodoUseCase: GetNearestDeadlineTodoUseCase,
+    private val getMyStudyMembersUseCase: GetMyStudyMembersUseCase,
+    private val getMyStudyCommentsUseCase: GetMyStudyCommentsUseCase,
+    private val postMyStudyCommentUseCase: PostMyStudyCommentUseCase
+) : ViewModel() {
+    private val _myStudyBasicState = MutableStateFlow<UiState<MyStudyBasicUiModel>>(Init)
+    val myStudyBasicState = _myStudyBasicState.asStateFlow()
+
+    private val _commentState = MutableStateFlow<UiState<List<MyStudyComment>?>>(Init)
+    val commentState = _commentState.asStateFlow()
+
+    /** 마이스터디 화면 정보 초기화 */
+    fun setUiState(studyId: Int) {
+        viewModelScope.launch {
+            _myStudyBasicState.value = Loading
+            _commentState.value = Loading
+
+            try {
+                val deferredDetail = async { getMyStudyDetailUseCase.invoke(studyId) }
+                val deferredRankAndScore = async { getMyStudyRankAndScoreUseCase.invoke(studyId) }
+                val deferredNearestDeadlineTodo = async { getNearestDeadlineTodoUseCase.invoke(studyId) }
+                val deferredStudyMembers = async { getMyStudyMembersUseCase.invoke(studyId) }
+                val deferredComments = async { getMyStudyCommentsUseCase.invoke(studyId = studyId) }
+
+                val basicInfo = MyStudyBasicUiModel(
+                    myStudyDetail = deferredDetail.await(),
+                    studyRank = deferredRankAndScore.await().rank,
+                    studyScore = deferredRankAndScore.await().score,
+                    nearestDeadlineTodo = deferredNearestDeadlineTodo.await(),
+                    studyMembers = deferredStudyMembers.await()
+                )
+                val comments = deferredComments.await()
+
+                _myStudyBasicState.value = Success(basicInfo)
+                _commentState.value = Success(comments)
+            } catch (failure: Failure) {
+                _myStudyBasicState.value = mapToErrorState(failure)
+                _commentState.value = mapToErrorState(failure)
+            }
+        }
+    }
+
+    /** 마이스터디 게시글 올리기 */
+    fun postComment(studyId: Int, comment: String) {
+        viewModelScope.launch {
+            _commentState.value = Loading
+            try {
+                postMyStudyCommentUseCase.invoke(studyId = studyId, comment = comment)
+                val newComments = getMyStudyCommentsUseCase.invoke(studyId = studyId)
+
+                _commentState.value = Success(newComments)
+            } catch (failure: Failure) {
+                _commentState.value = mapToErrorState(failure)
+            }
+        }
+    }
+
+    // TODO: 에러 별 메세지 매핑하기
+    private fun mapToErrorState(failure: Failure): Error {
+        return when (failure) {
+            is AppCrashFailure -> Error("에러가 발생하였습니다. 잠시 후 다시 시도해 주세요.", failure)
+            is BusinessFailure -> Error(failure.alertMessage!!, failure)
+            is DatabaseFailure -> Error("에러가 발생하였습니다. 잠시 후 다시 시도해 주세요.", failure)
+            is NetworkFailure -> Error("에러가 발생하였습니다. 잠시 후 다시 시도해 주세요.", failure)
+            is ServerFailure -> Error("에러가 발생하였습니다. 잠시 후 다시 시도해 주세요.", failure)
+            is UiFailure -> Error("에러가 발생하였습니다. 잠시 후 다시 시도해 주세요.", failure)
+            is UnexpectedDataFailure -> Error("에러가 발생하였습니다. 잠시 후 다시 시도해 주세요.", failure)
+            is UnexpectedUiFailure -> Error("에러가 발생하였습니다. 잠시 후 다시 시도해 주세요.", failure)
+            is ValidationFailure -> Error(failure.alertMessage!!, failure)
+        }
+    }
+}
+
+data class MyStudyBasicUiModel(
+    val myStudyDetail: MyStudyDetail,
+    val studyRank: Int,
+    val studyScore: Int,
+    val nearestDeadlineTodo: TodoSummary? = null,
+    val studyMembers: List<MyStudyMember>
+)

--- a/presentation/src/main/res/navigation/main_nav.xml
+++ b/presentation/src/main/res/navigation/main_nav.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/main_nav"
+    app:startDestination="@id/myStudyFragment">
+    <fragment
+        android:id="@+id/myStudyFragment"
+        android:name="com.takseha.presentation.view.mystudy.MyStudyFragment"
+        android:label="fragment_my_study"
+        tools:layout="@layout/fragment_my_study" />
+</navigation>


### PR DESCRIPTION
## ☝️연관된 이슈

<b>#81</b>

## ✌️구현 내용
> 📌 요약: 마이스터디 상세 화면 관련 View 및 ViewModel 구현

- `UiState` 정의
: Ui 데이터 관련 로딩/성공/실패 등을 정의하는 sealed class

- `MyStudyFragment` 구현
: UiState를 observe하는 기본적인 플로우 구현 (상세 메소드는 추후 구현)

- `MyStudyViewModel` 구현
: UiState에 담을 data를 호출, 그 과정에서의 에러 핸들링 및 상태 관리 플로우 구현 (상세 메소드는 추후 구현)
